### PR TITLE
Fixed invalid URLS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-javadoc",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Convert the canonical JSON into a java doc style representation",
   "main": "export.js",
   "scripts": {

--- a/templates/dataElement.ejs
+++ b/templates/dataElement.ejs
@@ -37,9 +37,9 @@ if (location.href.indexOf('is-external=true') == -1) {
       <li class="navBarCell1Rev">
         <a href="../overview-summary.html">Back to overview</a>
       </li>
-      <li class="navBarCell1Rev">
+      <!-- <li class="navBarCell1Rev">
         <a href="/../" target="_top">Back to <%= metaData.projectShorthand %> Website</a>
-      </li>
+      </li> -->
     </ul>
     <div class="aboutLanguage">
       <em>
@@ -48,6 +48,7 @@ if (location.href.indexOf('is-external=true') == -1) {
     </div>
   </div>
   <!-- ========= END OF TOP NAVBAR ========= -->
+  <a name="skip-navbar_top"></a>
   <!-- ======== START OF CLASS DATA ======== -->
   <div class="header">
     <div class="subTitle"><%= element.namespace %></div>

--- a/templates/info.ejs
+++ b/templates/info.ejs
@@ -23,10 +23,11 @@ if (location.href.indexOf('is-external=true') == -1) {
 <div class="topNav"><a name="navbar_top"></a><a href="#skip-navbar_top" title="Skip navigation links"></a><a name="navbar_top_firstrow"></a>
   <ul class="navList" title="Navigation">
     <li class="navBarCell1Rev"><a href="../overview-summary.html">Back to overview</a></li>
-    <li class="navBarCell1Rev"><a href="/../" target="_top">Back to <%= metaData.projectShorthand %> Website</a></li>
+    <!-- <li class="navBarCell1Rev"><a href="/../" target="_top">Back to <%= metaData.projectShorthand %> Website</a></li> -->
   </ul>
   <div class="aboutLanguage"><em><strong><%= metaData.projectShorthand %> Reference Model Version</strong></em><br/><%= namespace.name %></div>
 </div>
+<a name="skip-navbar_top"></a>
 <!-- ========= END OF TOP NAVBAR ========= -->
 <div class="contentContainer">
 <h2 title="Overview">Overview of <%= namespace.name %></h2>

--- a/templates/overview-summary.ejs
+++ b/templates/overview-summary.ejs
@@ -26,7 +26,7 @@
   <a name="navbar_top_firstrow"></a>
   <ul class="navList" title="Navigation">
     <li class="navBarCell1Rev">Overview</li>
-    <li class="navBarCell1Rev"><a href="/../" target="_top">Back to <%= metaData.projectShorthand %> Website</a></li>
+    <!-- <li class="navBarCell1Rev"><a href="/../" target="_top">Back to <%= metaData.projectShorthand %> Website</a></li> -->
   </ul>
   <div class="aboutLanguage">
     <em><strong><%= metaData.projectShorthand %>&nbsp;Reference&nbsp;Model</strong></em>
@@ -34,12 +34,12 @@
 </div>
 <div class="subNav">
   <ul class="navList">
-    <li><a href="index.html?overview-summary.html" target="_top">Frames</a></li>
+    <li><a href="index.html" target="_top">Frames</a></li>
     <li><a href="overview-summary.html" target="_top">No Frames</a></li>
   </ul>
-  <ul class="navList" id="allclasses_navbar_top">
+  <!-- <ul class="navList" id="allclasses_navbar_top">
     <li><a href="allclasses-noframe.html">All Classes</a></li>
-  </ul>
+  </ul> --> <!-- This is doesn't link to anything -->
   <div>
     <script type="text/javascript">
       //<![CDATA[
@@ -54,7 +54,7 @@
     //]]>
     </script>
   </div>
-  <a name="skip-navbar_top">
+  <a name="skip-navbar_top"></a>
   </a>
 </div>
 <!-- ========= END OF TOP NAVBAR ========= -->
@@ -114,12 +114,12 @@
     <li></li>
   </ul>
   <ul class="navList">
-    <li><a href="index.html?overview-summary.html" target="_top">Frames</a></li>
+    <li><a href="index.html" target="_top">Frames</a></li>
     <li><a href="overview-summary.html" target="_top">No Frames</a></li>
   </ul>
-  <ul class="navList" id="allclasses_navbar_bottom">
+  <!-- <ul class="navList" id="allclasses_navbar_bottom">
     <li><a href="allclasses-noframe.html">All Classes</a></li>
-  </ul>
+  </ul> --> <!-- This is doesn't link to anything -->
   <div>
     <script type="text/javascript">
     //<![CDATA[


### PR DESCRIPTION
Three separate (simple) issues repeated across all of the elements
produced the hundreds of errors.

1. The ‘back’ button used a relative url that wouldn’t be valid in the
context of the fhir page. Commented out for this release, will be put
back in shr.org updates
2. ‘Skip-navbar-top’ navigation links were unmatched. Matched them.
(Although… I can’t seem to find a way to actually access these links
using either mouse or keyboard, so it may be best to fully remove in
future release)
3. “Frame” url used ‘?’ reference path. This was marked as valid, and
there may a better way of using that reference. However, an identical
effect was met through linking to index.html, as the home page loaded
all of the frames.


Second part of resolution to: https://github.com/standardhealth/ballot/issues/12