### PR TITLE
Alphabetize namespace overview fix

### DIFF
--- a/export.js
+++ b/export.js
@@ -96,7 +96,7 @@ class SHR {
     for (const namespace of this.namespaces.list()) {
       const fileName = `${namespace.path}-pkg.html`;
       const filePath = path.join(this.outDirectory, namespace.path, fileName);
-      const ejsPkg = { elements: namespace.elements, namespace: namespace, metaData: this.metaData };
+      const ejsPkg = { elements: namespace.elements.sort(), namespace: namespace, metaData: this.metaData };
       renderEjsFile('templates/pkg.ejs', ejsPkg, filePath);
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-javadoc",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Convert the canonical JSON into a java doc style representation",
   "main": "export.js",
   "scripts": {


### PR DESCRIPTION
Fixes an issue in which clicking a namespace to narrow list of elements, shows an unordered list in the sidebar
<img width="687" alt="screen shot 2018-03-29 at 5 10 53 pm" src="https://user-images.githubusercontent.com/4651128/38113821-287a55c6-3374-11e8-87d2-594f54cd374b.png">
