### PR TITLE
Fix module require case for when filesystem is case sensitive (linux)

### DIFF
--- a/export.js
+++ b/export.js
@@ -4,7 +4,7 @@ const path = require('path');
 const bunyan = require('bunyan');
 const ncp = require('ncp').ncp;
 const Namespaces = require('./components/namespaces');
-const Elements = require('./components/Elements');
+const Elements = require('./components/elements');
 
 var rootLogger = bunyan.createLogger({ name: 'shr-json-javadoc' });
 var logger = rootLogger;


### PR DESCRIPTION
This require statement incorrectly capitalizes `element`.  Apparently MacOS doesn't mind, but Ubuntu does, which killed the build from `shr-cli`.  Everything else worked fine though.