### PR TITLE
Fixed lack of support for primitive type constraints

### DIFF
--- a/components/constraints.js
+++ b/components/constraints.js
@@ -149,13 +149,22 @@ class Constraints {
   // Handles type constraint. Will override datatype if top level
   // type constraint.
   typeConstraint(constraint, subpath) {
-    const element = this.elements[constraint.fqn];
-    var constraintName = (this.field.valueType === 'RefValue') ? `ref(${element.name})` : element.name;
-    if (this.field.valueType === 'RefValue') {
-      constraintName = `${constraintName}`;
-    }
+    let constraintName, href;
 
-    const href = `../${element.namespacePath}/${element.name}.html`;
+    const element = this.elements[constraint.fqn];
+    if (element) {
+      constraintName = (this.field.valueType === 'RefValue') ? `ref(${element.name})` : element.name;
+      if (this.field.valueType === 'RefValue') {
+        constraintName = `${constraintName}`; //TODO: This doesn't do anything...
+      }
+
+      href = `../${element.namespacePath}/${element.name}.html`;
+    } else if (constraint.fqn.indexOf('.') == -1) { //If primitive FQN
+      constraintName = constraint.fqn;
+    } else {
+      //Invalid constraint target
+      return;
+    }
 
     // Checks if type constraint is top level
     if (subpath === this.field.name && !this.inherited) {

--- a/components/constraints.js
+++ b/components/constraints.js
@@ -154,9 +154,6 @@ class Constraints {
     const element = this.elements[constraint.fqn];
     if (element) {
       constraintName = (this.field.valueType === 'RefValue') ? `ref(${element.name})` : element.name;
-      if (this.field.valueType === 'RefValue') {
-        constraintName = `${constraintName}`; //TODO: This doesn't do anything...
-      }
 
       href = `../${element.namespacePath}/${element.name}.html`;
     } else if (constraint.fqn.indexOf('.') == -1) { //If primitive FQN

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-javadoc",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Convert the canonical JSON into a java doc style representation",
   "main": "export.js",
   "scripts": {


### PR DESCRIPTION
Fixed: https://github.com/standardhealth/shr-cli/issues/92

Before, type constraints were assumed to lead to element definitions. This lead to a crash in the tooling.
This update fixes that assumption.