### PR TITLE
Fix crash for inherited entry fields

### DIFF
--- a/components/elements.js
+++ b/components/elements.js
@@ -127,6 +127,11 @@ class Elements {
     // Iterate over fields, handle valueType TBD separately
     element.fields.forEach((field) => {
       let inherited = false;
+      // We treat the "special" fields inherited because the element is an Entry as normal non-inherited fields
+      const isSpecialEntryField =
+        'inheritance' in field
+        && field.inheritance.from === 'shr.base.Entry'
+        && typeof hierarchyFields['shr.base.Entry'] === 'undefined';
       if (field.valueType === 'TBD') {
         field.title = field.fqn;
         field.path = '';
@@ -135,7 +140,7 @@ class Elements {
         field.name = fieldElement.name;
         field.description = fieldElement.description;
         field.path = fieldElement.namespacePath;
-        if ('inheritance' in field) {
+        if ('inheritance' in field && !isSpecialEntryField) {
           inherited = true;
           hierarchyFields[field.inheritance.from].push(field);
         }
@@ -143,7 +148,7 @@ class Elements {
       this.addToUsedBy(field.fqn, element);
       const cs = new Constraints(field, this.elements, this.config, inherited, this.configureForIG);
       field.pConstraints = cs.constraints;
-      if ('inheritance' in field && field.inheritance.status === 'overridden')
+      if ('inheritance' in field && field.inheritance.status === 'overridden' && !isSpecialEntryField)
         element.overridden = element.overridden.concat(cs.constraints);
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-javadoc",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Convert the canonical JSON into a java doc style representation",
   "main": "export.js",
   "scripts": {

--- a/templates/tables/definedTable.ejs
+++ b/templates/tables/definedTable.ejs
@@ -12,7 +12,7 @@
   <% } -%>
   <% if (element.fields) { -%>
     <% element.fields.forEach(function(field) { -%>
-      <% if (!('inheritance' in field)) { -%>
+      <% if (!('inheritance' in field) || (field.inheritance.from === 'shr.base.Entry' && !element.hierarchy.includes('shr.base.Entry'))) { -%>
         <%- include('fieldRow', { field: field, index: index }) -%>
       <% index += 1; } -%>
     <% }) -%>


### PR DESCRIPTION
This PR adds special support for "inherited" fields from `Entry`.  Prior to this fix, the model-doc exporter could crash when a data element constrains fields that are also in the `Entry` class.

In future versions, we will rework how entry works -- but this fix is the currently valid approach.