### PR TITLE
CIMPL6 Import

### DIFF
--- a/components/constraints.js
+++ b/components/constraints.js
@@ -79,8 +79,7 @@ class Constraints {
   // Creates datatype and cardinality constraint for non inherrited fields
   // Done separately because these occur outside of constraints object
   initializeConstraints() {
-    const isRef = this.field.valueType === 'RefValue';
-    const dValue = isRef ? `ref(${this.field.name})` : this.field.name;
+    const dValue = this.field.name;
     const path = this.field.name;
 
     // Datatype constraint
@@ -154,7 +153,7 @@ class Constraints {
 
     const element = this.elements[constraint.fqn];
     if (element) {
-      constraintName = (this.field.valueType === 'RefValue') ? `ref(${element.name})` : element.name;
+      constraintName = element.name;
 
       href = `../${element.namespacePath}/${element.name}.html`;
     } else if (constraint.fqn.indexOf('.') == -1) { //If primitive FQN

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-javadoc",
-  "version": "1.4.5",
+  "version": "6.0.0-beta.1",
   "description": "Convert the canonical JSON into a java doc style representation",
   "main": "export.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-javadoc",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0",
   "description": "Convert the canonical JSON into a java doc style representation",
   "main": "export.js",
   "scripts": {


### PR DESCRIPTION
Model changes needed to support CIMPL6.  The two most significant changes to the model are:

* Replaced `code`, `Coding`, and `CodeableConcept` with new `concept` primitive
* Removed `RefValue` in favor of using a field's "entry-ness" to determine if it should be a reference

For information on running w/ CIMPL6 source see:
https://github.com/standardhealth/shr-cli/pull/207

Marking as a DRAFT PR because all versions will need to be bumped to non-beta versions upon approval.