### PR TITLE
Decentralize loggerific errorMessages.txt

### DIFF
--- a/components/constraints.js
+++ b/components/constraints.js
@@ -228,7 +228,8 @@ class Constraints {
       this.cardConstraint(constraint, subpath);
       break;
     default:
-      logger.warn('Unknown constraint type %s. ERROR_CODE:TBD', cType);
+      // 07001, 'Unknown constraint type ${constraintType}.', 'Unknown', 'errorNumber'
+      logger.warn({ constraintType: cType }, '07001');
     }
   }
 

--- a/errorMessages.txt
+++ b/errorMessages.txt
@@ -1,0 +1,6 @@
+Number, Message, Solution, deduplicationKeys
+07001, 'Unknown constraint type ${constraintType}.', 'Unknown', 'errorNumber'
+07002, 'Compiling Documentation for ${count} namespaces...',,
+07003, 'Building documentation pages for ${count} elements...',,
+17001, 'Error rendering model doc: ${errorText}',  'Unknown', 'errorNumber'
+17002, 'Error copying files for export of model doc: ${errorText}',  'Unknown', 'errorNumber'

--- a/export.js
+++ b/export.js
@@ -40,7 +40,7 @@ function renderEjsFile(template, pkg, destination) {
   ejs.renderFile(path.join(__dirname, template), Object.assign(pkg, {makeHtml: makeHtml}), (error, htmlText) => {
     if (error) {
       // 17001, 'Error rendering model doc: ${errorText}',  'Unknown' , 'errorNumber'
-      logger.error({errorText: error }, '17001' );
+      logger.error({errorText: error.stack }, '17001' );
     }
     else fs.writeFileSync(destination, htmlText);
   });
@@ -103,7 +103,7 @@ class SHR {
     ncp(path.join(__dirname, 'required'), this.outDirectory, (error) => {
       if (error) {
         // 17002, 'Error copying files for export of model doc: ${errorText}',  'Unknown' , 'errorNumber'
-        logger.error({errorText : error},'17002' );
+        logger.error({errorText : error.stack},'17002' );
         return;
       }
     });
@@ -177,4 +177,8 @@ class SHR {
   }
 }
 
-module.exports = {setLogger, compileJavadoc, exportToPath};
+function errorFilePath() {
+  return require('path').join(__dirname, 'errorMessages.txt');
+}
+
+module.exports = {setLogger, compileJavadoc, exportToPath, errorFilePath};

--- a/export.js
+++ b/export.js
@@ -38,7 +38,10 @@ function makeHtml(md) {
 // Function to generate and write html from an ejs template
 function renderEjsFile(template, pkg, destination) {
   ejs.renderFile(path.join(__dirname, template), Object.assign(pkg, {makeHtml: makeHtml}), (error, htmlText) => {
-    if (error) logger.error('Error rendering model doc: %s', error);
+    if (error) {
+      // 17001, 'Error rendering model doc: ${errorText}',  'Unknown' , 'errorNumber'
+      logger.error({errorText: error }, '17001' );
+    }
     else fs.writeFileSync(destination, htmlText);
   });
 }
@@ -64,7 +67,8 @@ class SHR {
   // Read in the canonical json files
   // Assumes first level of directories are namespaces
   readFiles(cimcore) {
-    logger.info('Compiling Documentation for %s namespaces...', Object.keys(cimcore.namespaces).length);
+    // 07002, 'Compiling Documentation for ${count} namespaces...',,
+    logger.info({ count: Object.keys(cimcore.namespaces).length }, '07002');
     this.metaData = cimcore.projectInfo;
     for (const ns in cimcore.namespaces) {
       const namespace = this.namespaces.get(ns);
@@ -98,7 +102,8 @@ class SHR {
   copyRequiredFiles() {
     ncp(path.join(__dirname, 'required'), this.outDirectory, (error) => {
       if (error) {
-        logger.error('Error copying files for export of model doc: %s', error);
+        // 17002, 'Error copying files for export of model doc: ${errorText}',  'Unknown' , 'errorNumber'
+        logger.error({errorText : error},'17002' );
         return;
       }
     });
@@ -149,7 +154,8 @@ class SHR {
 
   // Builds pages for each data element
   buildDataElements() {
-    logger.info('Building documentation pages for %s elements...', this.elements.list().length);
+    // 07003, 'Building documentation pages for ${count} elements...',,
+    logger.info({ count: this.elements.list().length }, '07003');
     for (const element of this.elements.list()) {
       const ejsPkg = { element: element, metaData: this.metaData  };
       const fileName = `${element.name}.html`;


### PR DESCRIPTION
This takes the `errorMessages.txt` file which existed only in `shr-cli` and splits it into multiple files, so that each module has its own `errorMessages.txt` file. Also incorrectly numbered or otherwise broken errors were fixed.

PR 6/7
Affects:
- `shr-cli`
- `shr-text-import`
- `shr-expand`
- `shr-fhir-export`
- `shr-json-schema-export`
- `shr-json-javadoc`
- `shr-es6-export`