### PR TITLE
Entry fields are not inherited anymore

### DIFF
--- a/components/elements.js
+++ b/components/elements.js
@@ -159,12 +159,7 @@ class Elements {
     // Iterate over fields, handle valueType TBD separately
     element.fields.forEach((field) => {
       let inherited = false;
-      // We treat the "special" fields inherited because the element is an Entry as normal non-inherited fields
-      const isSpecialEntryField =
-        field.inheritance
-        && field.inheritedFrom.fqn === 'shr.base.Entry'
-        && typeof hierarchyFields['shr.base.Entry'] === 'undefined';
-      if (field.constructor.name === 'TBD') {
+      if (field.valueType === 'TBD') {
         field.title = field.fqn;
         field.path = '';
       } else {
@@ -172,7 +167,7 @@ class Elements {
         field.name = fieldElement.name;
         field.description = fieldElement.description;
         field.path = fieldElement.namespacePath;
-        if (field.inheritance && !isSpecialEntryField) {
+        if (field.inheritance) {
           inherited = true;
           hierarchyFields[field.inheritedFrom.fqn].push(field);
         }
@@ -184,7 +179,7 @@ class Elements {
       field.pConstraints = cs.constraints.filter(constraint => {
         return constraint.path == field.name;
       });
-      if (field.inheritance === 'overridden' && !isSpecialEntryField) {
+      if (field.inheritance === 'overridden') {
         element.overridden = element.overridden.concat(cs.constraints);
       } else {
         element.overridden = element.overridden.concat(cs.constraints.filter(constraint => {

--- a/templates/tables/definedTable.ejs
+++ b/templates/tables/definedTable.ejs
@@ -12,7 +12,7 @@
   <% } -%>
   <% if (element.fields) { -%>
     <% element.fields.forEach(function(field) { -%>
-      <% if (!(field.inheritance) || (field.inheritedFrom.fqn === 'shr.base.Entry' && !element.hierarchy.includes('shr.base.Entry'))) { -%>
+      <% if (!(field.inheritance)) { -%>
         <%- include('fieldRow', { field: field, index: index }) -%>
       <% index += 1; } -%>
     <% }) -%>


### PR DESCRIPTION
The things associated w/ Entry (ShrId, EntryId, EntryType) are now considered an implementation detail not to be in the model.

This is PR 4 of 7 in the overall effort to remove the need for the shr.base.Entry element.

1. shr-models (standardhealth/shr-models#49)
2. shr-text-import (standardhealth/shr-text-import#110)
3. shr-expand (standardhealth/shr-expand#49)
4. shr-json-javadoc
5. shr-json-schema-export (standardhealth/shr-json-schema-export#17)
6. shr-fhir-export (standardhealth/shr-fhir-export#165)
7. shr-es6-export (standardhealth/shr-es6-export#60)