### PR TITLE
Process and display subset constraints

### DIFF
--- a/components/constraints.js
+++ b/components/constraints.js
@@ -39,13 +39,26 @@ class Constraints {
   // Builds a new constraint row based on passed in parameter
   newConstraint(name, value, path, lastMod, href, back, front) {
     let targetTop = false;
-    if (href !== undefined) {
-      targetTop = href.includes('http');
-      //Special case for FHIR IG model doc instance
-      if (this.configureForIG && href.startsWith(`${this.config.fhirURL}/ValueSet/`)) {
-        href = href.replace(`${this.config.fhirURL}/ValueSet/`, '../../ValueSet-').concat('.html');
+    if(Array.isArray(href)) {
+      targetTop = href.some(subHref => subHref.includes('http'));
+      if(this.configureForIG) {
+        href = href.map(subHref => {
+          if(subHref.startsWith(`${this.config.fhirURL}/ValueSet/`)) {
+            subHref = subHref.replace(`${this.config.fhirURL}/ValueSet/`, '../../ValueSet-').concat('.html');
+          }
+          return subHref;
+        });
+      }
+    } else {
+      if (href !== undefined) {
+        targetTop = href.includes('http');
+        //Special case for FHIR IG model doc instance
+        if (this.configureForIG && href.startsWith(`${this.config.fhirURL}/ValueSet/`)) {
+          href = href.replace(`${this.config.fhirURL}/ValueSet/`, '../../ValueSet-').concat('.html');
+        }
       }
     }
+    
     let constraint = {
       name: name,
       value: value,
@@ -185,6 +198,22 @@ class Constraints {
     this.constraints.push(fConstraint);
   }
 
+  subsetConstraint(constraint, subpath) {
+    const name = 'Subset';
+    const value = constraint.subsetList.map(option => option.name);
+    const href = constraint.subsetList.map(option => {
+      const element = this.elements[option.fqn];
+      if(element) {
+        return `../${element.namespacePath}/${element.name}.html`;
+      } else {
+        return '';
+      }
+    });
+    const lastMod = constraint.lastModifiedBy.fqn;
+    const sConstraint = this.newConstraint(name, value, subpath, lastMod, href);
+    this.constraints.push(sConstraint);
+  }
+
   // Handles cardinality constraint
   cardConstraint(constraint, subpath) {
     const name = 'Cardinality';
@@ -251,6 +280,9 @@ class Constraints {
       });
       constraintsFilter.code.constraints.forEach((codeCon) => {
         this.fixedCode(codeCon, this.buildFullPath(codeCon));
+      });
+      constraintsFilter.subset.constraints.forEach((subCon) => {
+        this.subsetConstraint(subCon, this.buildFullPath(subCon));
       });
     }
   }

--- a/templates/tables/fieldRow.ejs
+++ b/templates/tables/fieldRow.ejs
@@ -20,7 +20,9 @@
   </td>
   <td class="colLast">
     <% field.pConstraints.forEach(function(constraint) { -%>
-      <% if (constraint.href) { -%>
+      <% if (Array.isArray(constraint.href)) { -%>
+        <%- include('valueList', { constraint: constraint }) -%>
+      <% } else if (constraint.href) { -%>
         <div class="block">
           <%= constraint.front %>
           <% if (constraint.targetTop) { -%>

--- a/templates/tables/overridenTable.ejs
+++ b/templates/tables/overridenTable.ejs
@@ -30,7 +30,9 @@
         <% } %>
       </td>
       <td class="colLast">
-        <% if (constraint.href) { -%>
+        <% if (Array.isArray(constraint.href)) { -%>
+          <%- include('valueList', { constraint: constraint }) -%>
+        <% } else if (constraint.href) { -%>
           <div class="block">
             <%= constraint.front %>
             <% if (constraint.targetTop) { -%>

--- a/templates/tables/valueList.ejs
+++ b/templates/tables/valueList.ejs
@@ -1,0 +1,17 @@
+<div class="block">
+  <%= constraint.front %>
+  <% constraint.href.forEach(function(subHref, subIndex, allHref) { -%>
+    <%_ if (subHref) { -%>
+      <%_ if (constraint.targetTop) { -%>
+        <a href="<%= subHref %>" target="_top"><%= constraint.value[subIndex] %></a>
+      <%_ } else { -%>
+        <a href="<%= subHref %>"><%= constraint.value[subIndex] %></a>
+      <%_ } -%>
+    <%_ } else { -%>
+      <%= constraint.value[subIndex] -%>
+    <%_ } _%>
+    <%_ if (allHref.length > 2 && subIndex < allHref.length - 1) { -%>, <% } -%>
+    <%_ if (subIndex == allHref.length - 2) { -%> or <% } -%>
+  <%_ }) -%>
+  <%= constraint.back %>
+</div>


### PR DESCRIPTION
When an entry's property can be one of several different types, the entry can apply a subset constraint
to limit that property to a subset of those types. The subset must contain at least two types.
Display these constraints with the label "Subtype" and a list of types for the value, including
links to other modeldoc pages when available.

This PR is 7/7. These PRs impact:
* `shr-grammar` https://github.com/standardhealth/shr-grammar/pull/46
* `shr-text-import` https://github.com/standardhealth/shr-text-import/pull/108
* `shr-models` https://github.com/standardhealth/shr-models/pull/47
* `shr-expand` https://github.com/standardhealth/shr-expand/pull/48
* `shr-fhir-export` https://github.com/standardhealth/shr-fhir-export/pull/161
* `shr-json-schema-export` https://github.com/standardhealth/shr-json-schema-export/pull/16
* `shr-json-javadoc`