### PR TITLE
Override option cardinality for elements with ChoiceValue

### DIFF
--- a/components/elements.js
+++ b/components/elements.js
@@ -114,13 +114,20 @@ class Elements {
     if (value === undefined) {
       return;
     } else if (value.constructor.name === 'ChoiceValue') {
+      let forcedMin = 0;
+      if(value.options.length == 1) {
+        // exactly one option isn't much of a choice
+        forcedMin = 1;
+      }
       value.options.forEach((option, index) => {
-        const card = option.card;
-        option.card = undefined;
+        if(!option.card) {
+          option.card = {};
+        }
+        option.card.min = forcedMin;
+        option.card.max = 1;
         this.addToUsedBy(option.identifier.fqn, element);
         const optionValue = this.valueConstraints(element, option, `Value (Choice ${index+1})`);
         element.pValue.push(optionValue);
-        option.card = card;
       });
     } else {
       this.addToUsedBy(value.identifier.fqn, element);


### PR DESCRIPTION
When an element's value is of type ChoiceValue, specific cardinalities are used for the value's options.
If the ChoiceValue has exactly one option, the option's cardinality is "1..1".
If the ChoiceValue has two or more options, each option's cardinality is "0..1".

Considering the matter more deeply, I am wondering if it would make more sense to have the logic that enforces these cardinalities earlier in the processing pipeline. If this is the case, this pull request can be closed, and the logic can be implemented elsewhere.